### PR TITLE
Display request creation date

### DIFF
--- a/bot/adminActions.js
+++ b/bot/adminActions.js
@@ -162,6 +162,7 @@ async function showRequestsByStatus(bot, chatId, estado, page = 1, callbackQuery
 
   requests.forEach((r, i) => {
     text += `*${(skip + i + 1)}.* ${r.fullName || 'Sin nombre'}\n`;
+    text += `🗓 ${r.createdAt.toLocaleDateString('es-ES')}\n`;
     text += `💬 ${r.text.slice(0, 80)}\n`;
     text += `💰 ${r.budget || 'Sin presupuesto'}\n\n`;
   });


### PR DESCRIPTION
## Summary
- show creation date in approved/rejected request lists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aa952acbc832b81e6e6b68a862558