### PR TITLE
Fix pagination context for text commands

### DIFF
--- a/bot/adminActions.js
+++ b/bot/adminActions.js
@@ -4,6 +4,11 @@ const escapeMarkdown = require('../utils/escapeMarkdown');
 // Paginación en memoria por usuario
 const paginationState = {}; // { userId: { status, page } }
 
+// Inicializa o reinicia la paginación para un admin
+function initPaginationState(userId, status) {
+  paginationState[userId] = { status, page: 1 };
+}
+
 function registerAdminActions(bot) {
   bot.on('callback_query', async (query) => {
     const [action, idOrState] = query.data.split('_');
@@ -61,7 +66,7 @@ function registerAdminActions(bot) {
     if (action === 'list' && statusMap.list[idOrState]) {
       const estado = statusMap.list[idOrState];
       const page = 1;
-      paginationState[userId] = { status: estado, page };
+      initPaginationState(userId, estado);
 
       if (estado === 'pendiente') {
         return showPendingRequests(bot, chatId, page, query.id);
@@ -224,5 +229,6 @@ module.exports = {
   registerAdminActions,
   showRequestsByStatus,
   showPendingRequests,
-  showAdminStats
+  showAdminStats,
+  initPaginationState
 };

--- a/bot/adminHandlers.js
+++ b/bot/adminHandlers.js
@@ -1,5 +1,9 @@
-// Asegúrate de que estas funciones estén exportadas desde adminActions.js
-const { showRequestsByStatus, showPendingRequests } = require('./adminActions');
+// Funciones provenientes de adminActions.js
+const {
+  showRequestsByStatus,
+  showPendingRequests,
+  initPaginationState,
+} = require('./adminActions');
 
 // 🧑‍💼 Comando /admin con panel interactivo
 async function handleAdminCommand(bot, msg) {
@@ -31,14 +35,17 @@ async function handleAdminMessage(bot, msg) {
   }
 
   if (text.includes('ver aprobadas')) {
+    initPaginationState(msg.from.id.toString(), 'aprobada');
     return showRequestsByStatus(bot, chatId, 'aprobada');
   }
 
   if (text.includes('ver rechazadas')) {
+    initPaginationState(msg.from.id.toString(), 'rechazada');
     return showRequestsByStatus(bot, chatId, 'rechazada');
   }
 
   if (text.includes('ver pendientes')) {
+    initPaginationState(msg.from.id.toString(), 'pendiente');
     return showPendingRequests(bot, chatId);
   }
 


### PR DESCRIPTION
## Summary
- export a pagination initializer in `adminActions.js`
- reset pagination state from admin text commands

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684beb349804832b831667af7aebe720